### PR TITLE
Fix macro for erlang 27

### DIFF
--- a/src/clique_table.erl
+++ b/src/clique_table.erl
@@ -28,11 +28,11 @@
 -include("clique_status_types.hrl").
 
 -define(MAX_LINE_LEN, 100).
--define(else, true).
+-define(ELSE_COMPAT, true).
 -define(MINWIDTH(W),
         if W =< 0 ->
                 1;
-           ?else ->
+           ?ELSE_COMPAT ->
                 W
         end).
 


### PR DESCRIPTION
There's a custom macro for the word "else" that breaks in Erlang 27.  I renamed it to ELSE_COMPAT to get it compiling. 