### PR TITLE
explicitly allow '*' in specs for clique_usage:register/2

### DIFF
--- a/src/clique.erl
+++ b/src/clique.erl
@@ -86,7 +86,7 @@ register_command(Cmd, Keys, Flags, Fun) ->
 
 %% @doc Register usage for a given command sequence. Lookups are by longest
 %% match.
--spec register_usage([string()], clique_usage:usage()) -> true.
+-spec register_usage([string()|'*'], clique_usage:usage()) -> true.
 register_usage(Cmd, Usage) ->
     clique_usage:register(Cmd, Usage).
 

--- a/src/clique_usage.erl
+++ b/src/clique_usage.erl
@@ -56,7 +56,7 @@ teardown() ->
 
 %% @doc Register usage for a given command sequence. Lookups are by longest
 %% match.
--spec register([string()], usage()) -> true.
+-spec register([string()|'*'], usage()) -> true.
 register(Cmd, Usage) ->
     ets:insert(?usage_table, {Cmd, Usage}).
 


### PR DESCRIPTION
else, dialyzer will complain about specs like this:

```
clique:register_usage(["riak-admin", "tictacaae", "rebuild-schedule", '*'], ...)
```